### PR TITLE
nvidia-gds v12.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,15 @@ source:
 
 build:
   number: 0
-  noarch: generic
+  # This is 'technically' not a noarch package: only supported on linux-64 and linux-aarch64
+  # Therefore, 'noarch: generic' is replaced with 'skip: true' to avoid building on unsupported platforms.
+  skip: true  # [not linux]
 
 requirements:
   run:
-    - __linux
+    # Remove '__linux' as it might not be handled properly on PBP
+    # Also, see above note about 'skip: true'
+    # Ref: https://docs.conda.io/projects/conda/en/stable/user-guide/tasks/manage-virtual.html
     - libcufile 1.13.1.3
     - libcufile-dev 1.13.1.3
     - libcufile-static 1.13.1.3
@@ -29,11 +33,15 @@ about:
   license_file: LICENSE.txt
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: GPU Direct Storage meta-package
   description: |
     Meta-package containing all the available packages required for libcufile.
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
+  skip-lints:
+    - license_file_overspecified
   recipe-maintainers:
     - conda-forge/cuda


### PR DESCRIPTION
nvidia-gds 12.8.1

**Destination channel:** defaults

### Links

- [PKG-11173](https://anaconda.atlassian.net/browse/PKG-11173) 

### Explanation of changes:

- Missing package from CUDA 12.8 release

[PKG-11173]: https://anaconda.atlassian.net/browse/PKG-11173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ